### PR TITLE
Fix SyntaxError

### DIFF
--- a/templates/definition.ejs
+++ b/templates/definition.ejs
@@ -7,7 +7,7 @@
 <%_   })
     };
     if (schema.isRef && schema.type !== name) { _%>
-import <%= schema.type _%> from "./<%= schema.type _%>";
+import <%= schema.type %> from "./<%= schema.type _%>";
 <%_ }; _%>
 
 <%_ if (schema.isArray) {


### PR DESCRIPTION
An error occurred when generating the model in the example directory yaml file.

```bash
$ ./bin/openapi-ts-gen.js generate ./example/petstore.yml --namespace PetStore --dist types
Generated: /Users/ryo-rm/tmp/openapi-ts-gen/types/models/Pet.ts
{ SyntaxError: '=' expected. (4:16)
  2 | /* tslint:disable */
  3 | /* eslint-disable */
> 4 | import Petfrom "./Pet";
    |                ^
  5 |
  6 | type Pets= Pet[];
  7 | export default Pets;
```

https://ejs.co/

> _%> ‘Whitespace Slurping’ ending tag, removes all whitespace after it