### PR TITLE
Fix enum syntax

### DIFF
--- a/templates/definition.ejs
+++ b/templates/definition.ejs
@@ -21,12 +21,23 @@ export interface <%= name _%>List {
 <%_ }) _%>
 }
 <%_   };
-    } else if (schema.enum.length) { _%>
-enum <%= name _%> {
-<%_ schema.enum.forEach((val, index) => { _%>
-  <%= val _%> = "<%= val _%>"<%_ if (index !== 0) {%>,<%_ } _%>
-<%_ })%>
+    } else if (schema.enum.length) {
+      // An enum member cannot have a numeric name
+      // constain numeric
+      if (schema.enum.filter((e) => Number.isFinite(Number(e))).length) { _%>
+type <%= name %> = <% schema.enum.forEach((val, index, array) => { _%>
+<%_ if (typeof val !== 'string') { _%>
+<%= val _%><%_ } else { _%>"<%= val _%>"
+<%_ } %><%= (index !== array.length - 1)? '|' : ';'  _%>
+<%_ }) _%>
+      <%_ } else {
+        // only string
+_%> enum <%= name _%> {
+<%_ schema.enum.forEach((val) => { _%>
+  <%= val %> = "<%= val _%>",
+<%_ })-%>
 }
+      <%_ } _%>
 
 export default <%= name _%>
 <%_ } else { _%>


### PR DESCRIPTION
Fixed an error that occurred in Enum generation.

- yaml
```yml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      tags:
        - pets
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: integer
            format: int32
      responses:
        '200':
          description: A paged array of pets
          headers:
            x-next:
              description: A link to the next page of responses
              schema:
                type: string
          content:
            application/json:    
              schema:
                $ref: "#/components/schemas/EnumString"
components:
  schemas:
    EnumString:
      type: string
      enum:
        - a
        - b
        - c
    EnumInteger:
      type: integer
      enum:
        - 1
        - 2
        - 3
    EnumMixed:
      type: string
      enum:
        - "1"
        - a
```

- before
```
$ ./bin/openapi-ts-gen.js generate example/petstore.yml --namespace PetStore --dist types
{ SyntaxError: ',' expected. (6:11)
  4 | 
  5 | enum EnumString{
> 6 |   a= "a"  b= "b",  c= "c",
    |           ^
  7 | }
  8 | 
  9 | export default EnumString
```

- after
```ts
// THIS FILE IS GENERATED BY CODE GENERATOR. DO NOT CHANGE MANUALLY.
/* tslint:disable */
/* eslint-disable */

enum EnumString {
  a = "a",
  b = "b",
  c = "c"
}

export default EnumString;
```
```ts
// THIS FILE IS GENERATED BY CODE GENERATOR. DO NOT CHANGE MANUALLY.
/* tslint:disable */
/* eslint-disable */

type EnumInteger = 1 | 2 | 3;
export default EnumInteger;
```
```ts
// THIS FILE IS GENERATED BY CODE GENERATOR. DO NOT CHANGE MANUALLY.
/* tslint:disable */
/* eslint-disable */

type EnumMixed = "1" | "a";
export default EnumMixed;
```